### PR TITLE
Make KA Engineering logo link back to /

### DIFF
--- a/src/post-template.htm
+++ b/src/post-template.htm
@@ -12,7 +12,7 @@
 <body>
     <div id="left-bar">
         <h1 class="logo">
-            KA <span class="engineering">Engineering</span>
+            <a href="/">KA <span class="engineering">Engineering</span></a>
         </h1>
         <h1 class="logo mobile">
             <!-- We'll bind a handler to this that'll toggle the menu -->

--- a/src/styles/post-template.less
+++ b/src/styles/post-template.less
@@ -83,6 +83,11 @@ body {
         text-align: left;
         text-transform: uppercase;
 
+        a {
+            color: @leftBarTextColor;
+            text-decoration: none;
+        }
+
         &.mobile {
             font-size: 24px;
             display: none;


### PR DESCRIPTION
Since there's currently no way aside from manually changing the URI in the browser to go back to the home page from viewing a specific post.

On mobile I wasn't super sure how to make this happen since we do something different with the header. @brownhead any guidelines?
