### PR TITLE
Add async_scripts parameter to frontmatter.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Create a new file in ``src/posts/`` with a ``.rst`` extension. It should follow 
 	published_on: January 1, 2020
 	author: Jane Doe
 	team: Web Frontend
+	async_scripts: ["javascript/some-javascript-i-want.js"]
 	...
 
 	Hello ``world``!

--- a/src/post-template.htm
+++ b/src/post-template.htm
@@ -9,6 +9,10 @@
 
     <!-- inject:head:css -->
     <!-- endinject -->
+
+    {{#displayed_post.async_scripts}}
+    <script async src="{{.}}"></script>
+    {{/displayed_post.async_scripts}}
 </head>
 <body>
     <div id="left-bar">

--- a/src/post.py
+++ b/src/post.py
@@ -71,6 +71,7 @@ class Post(object):
                 datetime.datetime.strptime(frontmatter["published_on"],
                                            "%B %d, %Y"))
         self.author = frontmatter["author"]
+        self.async_scripts = frontmatter.get("async_scripts", [])
         self.raw_content = content
 
     def get_html_content(self):
@@ -99,5 +100,6 @@ class Post(object):
             "published_on_html":
                 datetime_to_html_string(self.published_on),
             "author": info.authors[self.author],
+            "async_scripts": self.async_scripts,
             "permalink": "/posts/" + self.get_output_name()
         }


### PR DESCRIPTION
Now posts can specify scripts to add to the page. They will be added
via `<script async src="bla"></script>` tags in the `<head>` section.

Test Plan:
1) Create an `alert.js` file in `src/javascript/` and write
   `alert("hello")` in it.
2) Add `/javascript/alert.js` as an async script for one of the posts.
3) Run `make serve` and go to the post page. See the alert pop up.
