### PR TITLE
Add support for stylesheets, post-article scripts

### DIFF
--- a/src/javascript/katex-entry.js
+++ b/src/javascript/katex-entry.js
@@ -1,0 +1,20 @@
+/*
+ * Entry point to auto-render KaTeX in the article once loaded.
+ */
+var id = setInterval(function() {
+    if (!(window.katex && window.renderMathInElement)) {
+        return;
+    }
+    window.clearInterval(id);
+    var article = document.getElementsByTagName('article')[0];
+
+    // We add single-dollar delimiters because escaping Markdown is annoying.
+    // Note that $$ must come before $ for the former to ever be parsed.
+    var delimiters = [
+        {left: "$$", right: "$$", display: true},
+        {left: "$", right: "$", display: false},  // must come after $$
+        {left: "\\[", right: "\\]", display: true},
+        {left: "\\(", right: "\\)", display: false}
+    ];
+    renderMathInElement(article, { delimiters: delimiters });
+}, 100);

--- a/src/javascript/katex-entry.js
+++ b/src/javascript/katex-entry.js
@@ -1,20 +1,22 @@
 /*
  * Entry point to auto-render KaTeX in the article once loaded.
  */
-var id = setInterval(function() {
-    if (!(window.katex && window.renderMathInElement)) {
-        return;
-    }
-    window.clearInterval(id);
-    var article = document.getElementsByTagName('article')[0];
+(function() {
+    var id = setInterval(function() {
+        if (!(window.katex && window.renderMathInElement)) {
+            return;
+        }
+        window.clearInterval(id);
+        var article = document.getElementsByTagName('article')[0];
 
-    // We add single-dollar delimiters because escaping Markdown is annoying.
-    // Note that $$ must come before $ for the former to ever be parsed.
-    var delimiters = [
-        {left: "$$", right: "$$", display: true},
-        {left: "$", right: "$", display: false},  // must come after $$
-        {left: "\\[", right: "\\]", display: true},
-        {left: "\\(", right: "\\)", display: false}
-    ];
-    renderMathInElement(article, { delimiters: delimiters });
-}, 100);
+        // We add single-dollar delimiters because escaping Markdown is annoying.
+        // Note that $$ must come before $ for the former to ever be parsed.
+        var delimiters = [
+            {left: "$$", right: "$$", display: true},
+            {left: "$", right: "$", display: false},  // must come after $$
+            {left: "\\[", right: "\\]", display: true},
+            {left: "\\(", right: "\\)", display: false}
+        ];
+        renderMathInElement(article, { delimiters: delimiters });
+    }, 100);
+})();

--- a/src/post-template.htm
+++ b/src/post-template.htm
@@ -13,6 +13,10 @@
     {{#displayed_post.async_scripts}}
     <script async src="{{.}}"></script>
     {{/displayed_post.async_scripts}}
+
+    {{#displayed_post.stylesheets}}
+    <link rel="stylesheet" href="{{.}}"></link>
+    {{/displayed_post.stylesheets}}
 </head>
 <body>
     <div id="left-bar">
@@ -81,6 +85,9 @@
                 {{{html_content}}}
             </div>
         </article>
+        {{#displayed_post.postcontent_scripts}}
+        <script async src="{{.}}"></script>
+        {{/displayed_post.postcontent_scripts}}
         <div class="keep-reading-buttons">
             <div class="keep-reading-cell keep-reading-left">
                 {{#previous_post}}

--- a/src/post.py
+++ b/src/post.py
@@ -72,6 +72,8 @@ class Post(object):
                                            "%B %d, %Y"))
         self.author = frontmatter["author"]
         self.async_scripts = frontmatter.get("async_scripts", [])
+        self.postcontent_scripts = frontmatter.get("postcontent_scripts", [])
+        self.stylesheets = frontmatter.get("stylesheets", [])
         self.raw_content = content
 
     def get_html_content(self):
@@ -101,5 +103,7 @@ class Post(object):
                 datetime_to_html_string(self.published_on),
             "author": info.authors[self.author],
             "async_scripts": self.async_scripts,
-            "permalink": "/posts/" + self.get_output_name()
+            "postcontent_scripts": self.postcontent_scripts,
+            "permalink": "/posts/" + self.get_output_name(),
+            "stylesheets": self.stylesheets,
         }


### PR DESCRIPTION
Summary:
Pull request #33 adds support for asynchronous scripts, which is great!
For full KaTeX support, though, we need to pull in CSS and fonts;
to auto-render, we need to wait until the DOM is loaded.
This patch adds a few more fields to the frontmatter that do just that.

It also adds a simple KaTeX entry point,
both for testing that this works and for actual usage.

It doesn't include font support,
because I don't think that'd play nice with the CSS inlining we have.

Depends on #33.

Test Plan:

Sample input:

```
title: Testing math
published_on: August 28, 2015
author: R. J. Drofnats
team: Web Frontend
async_scripts: ["https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.js", "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/contrib/auto-render.min.js"]
stylesheets: ["https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.css"]
postcontent_scripts: ["/javascript/katex-entry.js"]
...

Many people know that $A = \pi r^2$.
Leonhard Euler came to fame for showing that $$\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6},$$
using novel techniques whose proof would follow much later.
```

Sample output:

> ![Sample output](https://cloud.githubusercontent.com/assets/4317806/9551838/8cbd2dc8-4d68-11e5-9f8f-4f35d3797ab1.png)
