### PR TITLE
Don't break when there's no upcoming post

### DIFF
--- a/src/post-template.htm
+++ b/src/post-template.htm
@@ -40,6 +40,7 @@
                 <a href="/rss.xml"><span class="sr-only">Subscribe with RSS</span><svg class="font-awesome-svg" viewBox="0 0 1792 1792" aria-hidden="true"><path d="M576 1344q0 80-56 136t-136 56-136-56-56-136 56-136 136-56 136 56 56 136zm512 123q2 28-17 48-18 21-47 21h-135q-25 0-43-16.5t-20-41.5q-22-229-184.5-391.5t-391.5-184.5q-25-2-41.5-20t-16.5-43v-135q0-29 21-47 17-17 43-17h5q160 13 306 80.5t259 181.5q114 113 181.5 259t80.5 306zm512 2q2 27-18 47-18 20-46 20h-143q-26 0-44.5-17.5t-19.5-42.5q-12-215-101-408.5t-231.5-336-336-231.5-408.5-102q-25-1-42.5-19.5t-17.5-43.5v-143q0-28 20-46 18-18 44-18h3q262 13 501.5 120t425.5 294q187 186 294 425.5t120 501.5z" fill="#fff"/></svg></a>
             </div>
         </section>
+        {{#upcoming_post}}
         <section>
             <h2 class="section-heading">Upcoming fortnightly post</h2>
             <div class="post-blurb {{upcoming_post.team_class}}">
@@ -50,6 +51,7 @@
                 </div>
             </div>
         </section>
+        {{/upcoming_post}}
         <section>
             <h2 class="section-heading">Latest posts</h2>
             {{#posts}}


### PR DESCRIPTION
Summary:
~~I don't think there's anyone actually after me in the publish queue,
so when I publish my post tomorrow I'll set `upcoming_post = None`.
That currently breaks the sidebar. This patch fixes that.~~

**edit:** there is a next post, but this patch is probably still good!

I'm PRing this just to get the Travis build.
If there are no objections by the time I'm ready to publish my post,
I'll just merge this in with that commit.

Test Plan:
At the bottom of `src/info.py`,
change the value of `upcoming_post` to `None`.
Build and make sure that the app doesn't break
and that no "upcoming post" is displayed in the sidebar.

Reviewers: @brownhead 
