### PR TITLE
Remove wsgiref as a dependency (for Python 3 compatibility)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ PyYAML==3.12
 Pygments==2.0.2
 docutils==0.12
 pystache==0.5.4
-wsgiref==0.1.2
 Markdown==2.6.2


### PR DESCRIPTION
Summary:
wsgiref is Python 2-only, so it causes `make deps`
to fail when using a Python 3 virtualenv.

After removing it, `make deps` and `make serve`
commands still work as expected.