### PR TITLE
Remove bower in favor of npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,6 @@ deps:
 	env/bin/pip install -r ./khan-linter/requirements.txt
 	env/bin/pip install -r ./requirements.txt
 
-	# Install our bower dependencies
-	npm install bower
-	node_modules/.bin/bower install normalize.css
-
 	# Install khan-linter's dependencies
 	cd ./khan-linter; npm install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -584,12 +584,6 @@
                 "hoek": "2.16.3"
             }
         },
-        "bower": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-            "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
-            "dev": true
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -6409,6 +6403,11 @@
                 "trim-x": "3.0.0",
                 "white-space-x": "3.0.0"
             }
+        },
+        "normalize.css": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.0.tgz",
+            "integrity": "sha512-iXcbM3NWr0XkNyfiSBsoPezi+0V92P9nj84yVV1/UZxRUrGczgX/X91KMAGM0omWLY2+2Q1gKD/XRn4gQRDB2A=="
         },
         "npm-run-path": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "version": "0.0.1",
     "private": true,
     "devDependencies": {
-        "bower": "^1.8.2",
         "gulp": "^3.9.1",
         "gulp-concat": "^2.6.1",
         "gulp-foreach": "^0.1.0",
@@ -17,5 +16,8 @@
         "gulp-webserver": "^0.9.1",
         "http-server": "^0.11.1",
         "yargs": "^11.0.0"
+    },
+    "dependencies": {
+        "normalize.css": "^8.0.0"
     }
 }

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -41,7 +41,7 @@ function inlinePostCss(inputGlob, outputDir) {
             // Gather all of the CSS we want to inline in this post
             var css = (gulp
                 .src(["styles/post-template.less",
-                      "../bower_components/normalize.css",
+                      "../node_modules/normalize.css/normalize.css",
                       "styles/pygments.css"])
                 .pipe(less())
                 .pipe(concat("all.css")))


### PR DESCRIPTION
Summary:
Install normalize.css with npm and remove bower from the build
process.