### PR TITLE
Make body and title sizes more responsive

### DIFF
--- a/src/styles/post-template.less
+++ b/src/styles/post-template.less
@@ -10,6 +10,19 @@
 @designColor: #ab59c6;
 @wtfColor: #ff00af;
 
+@baseFontSize: 14px;
+// Modular scale: Major second
+@ratioSm: 1.125em;
+// Title font size is two steps up in the scale
+@titleFontSizeSm: pow(@ratioSm, 2);
+
+// Use a larger base font size and higher contrast
+// between title and copy on larger viewports
+@baseFontSizeLg: 16px;
+// Modular scale: Major third
+@ratioLg: 1.25em;
+@titleFontSizeLg: pow(@ratioLg, 2);
+
 html, body {
     height: 100%;
     margin: 0;
@@ -18,8 +31,12 @@ html, body {
 body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     background-color: #FEFEFE;
-    font-size: 14px;
+    font-size: @baseFontSize;
     width: 920px;
+
+    @media (min-width: @doubleColumnMaxWidth) {
+        font-size: @baseFontSizeLg;
+    }
 
     @media (max-width: @doubleColumnMaxWidth) {
         width: 100%;
@@ -189,6 +206,7 @@ body {
         border-left: 1px solid transparent;
         padding-left: 10px;
         margin-left: -10px;
+        font-size: @baseFontSize;
 
         @media (max-width: @doubleColumnMaxWidth) {
             border-left: 10px solid transparent;
@@ -301,10 +319,14 @@ body {
     .title a {
         letter-spacing: 1px;
         margin-bottom: 8px;
-        font-size: 28px;
+        font-size: @titleFontSizeSm;
         line-height: 1;
         color: @contentTextColor;
         text-decoration: none;
+
+        @media (min-width: @doubleColumnMaxWidth) {
+            font-size: @titleFontSizeLg;
+        }
 
         &:hover, &:focus {
             text-decoration: underline;
@@ -341,7 +363,7 @@ body {
     .body {
         margin-top: 30px;
         line-height: 1.5;
-        width: 500px;
+        width: 580px;
 
         @media (max-width: @doubleColumnMaxWidth) {
             width: 100%;


### PR DESCRIPTION
Improves legibility on desktop-size screens by

1. Increasing the base font size from 14px to 16px
2. Increasing the contrast between title and body text

Implements the following:

* Mobile/tablets: base font size of 14px, title:body ratio of 1.27
* Desktop: base font size of 16px, title:body ratio of 1.56
  * I increased the body container size 80px to keep the line
  length roughly the same with the increased font size.

### Desktop (Before)

<img width="510" alt="Desktop (Before)" src="https://user-images.githubusercontent.com/2379650/40023080-ebeb0806-5797-11e8-9ede-8c4f46430547.png">

### Desktop (After)

<img width="510" alt="Desktop (After)" src="https://user-images.githubusercontent.com/2379650/40023049-d695a934-5797-11e8-9ec8-53782a52b439.png">

Note: Ignore the underline under the logo: I was hovering over it when I took the screenshot 😺 

### Mobile (Before)

<img width="255" alt="Mobile (Before)" src="https://user-images.githubusercontent.com/2379650/40023169-2fa13fd4-5798-11e8-87af-3d9cdf32ef5f.png">

### Mobile (After)

<img width="247" alt="Mobile (After)" src="https://user-images.githubusercontent.com/2379650/40023136-175244dc-5798-11e8-8839-169e61639266.png">




Partially addresses #68